### PR TITLE
renamed get_query_set to get_queryset

### DIFF
--- a/docs/overview.txt
+++ b/docs/overview.txt
@@ -206,7 +206,7 @@ A manager for retrieving tags used by a particular model.
 
 Defines the following methods:
 
-* ``get_query_set()`` -- as this method is redefined, any ``QuerySets``
+* ``get_queryset()`` -- as this method is redefined, any ``QuerySets``
   created by this model will be initially restricted to contain the
   distinct tags used by all the model's instances.
 

--- a/tagging/managers.py
+++ b/tagging/managers.py
@@ -2,6 +2,8 @@
 Custom managers for Django models registered with the tagging
 application.
 """
+
+import django
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
@@ -12,10 +14,14 @@ class ModelTagManager(models.Manager):
     """
     A manager for retrieving tags for a particular model.
     """
-    def get_query_set(self):
+    def get_queryset(self):
         ctype = ContentType.objects.get_for_model(self.model)
         return Tag.objects.filter(
             items__content_type__pk=ctype.pk).distinct()
+
+    # TODO: drop this
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset
 
     def cloud(self, *args, **kwargs):
         return Tag.objects.cloud_for_model(self.model, *args, **kwargs)


### PR DESCRIPTION
Method get_query_set is deprecated since Django 1.6, produces unpleasant warnings with Django 1.7 and won't work any more with Django 1.8.