### PR TITLE
Change homepage.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     description = 'Generic tagging application for Django',
     author = 'Jonathan Buchanan',
     author_email = 'jonathan.buchanan@gmail.com',
-    url = 'https://code.google.com/p/django-tagging/',
+    url = 'https://github.com/Fantomas42/django-tagging',
     packages = packages,
     data_files = data_files,
     classifiers = [


### PR DESCRIPTION
Fantomas42 seems to be the de facto maintainer of django-tagging now.