### PR TITLE
Don't return a tag weight greater than max_weight

### DIFF
--- a/tagging/utils.py
+++ b/tagging/utils.py
@@ -233,7 +233,9 @@ def _calculate_tag_weight(weight, max_weight, distribution):
     if distribution == LINEAR or max_weight == 1:
         return weight
     elif distribution == LOGARITHMIC:
-        return math.log(weight) * max_weight / math.log(max_weight)
+        return min(
+            math.log(weight) * max_weight / math.log(max_weight),
+            max_weight)
     raise ValueError(
         _('Invalid distribution algorithm specified: %s.') % distribution)
 


### PR DESCRIPTION
Values greater than max_weight will cause the font not to be set when
calculating the cloud, as the greatest threshold will be equal to the
max_weight.

I came across this issue when looking at the patches applied to the Debian
package [1][2], which reference the Google Code issue tracker [3].

1: https://anonscm.debian.org/cgit/python-modules/packages/python-django-tagging.git/plain/debian/patches/fix_calc_tag_weight?id=273bb4873a0a8457c724304bf09e37bc11596dc1
2: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=525770
3: https://code.google.com/archive/p/django-tagging/issues/91