### PR TITLE
Fixed parse_tag_input() to handle a single tag that contains a space.

### DIFF
--- a/tagging/tests/tests.py
+++ b/tagging/tests/tests.py
@@ -1081,6 +1081,7 @@ class TestTagFieldInForms(TestCase):
         spaces = Tag.objects.create(name='spa ces')
         comma = Tag.objects.create(name='com,ma')
         self.assertEqual(edit_string_for_tags([plain]), 'plain')
+        self.assertEqual(edit_string_for_tags([spaces]), '"spa ces"')
         self.assertEqual(edit_string_for_tags([plain, spaces]),
                          'plain, spa ces')
         self.assertEqual(edit_string_for_tags([plain, spaces, comma]),

--- a/tagging/utils.py
+++ b/tagging/utils.py
@@ -121,7 +121,14 @@ def edit_string_for_tags(tags):
         glue = ', '
     else:
         glue = ' '
-    return glue.join(names)
+    result = glue.join(names)
+
+    # If we only had one name, and it had spaces, we need to enclose it in quotes.
+    # Otherwise, it's interpreted as two tags.
+    if len(names) == 1 and use_commas:
+        result = '"' + result + '"'
+
+    return result
 
 
 def get_queryset_and_model(queryset_or_model):

--- a/tagging/utils.py
+++ b/tagging/utils.py
@@ -123,7 +123,8 @@ def edit_string_for_tags(tags):
         glue = ' '
     result = glue.join(names)
 
-    # If we only had one name, and it had spaces, we need to enclose it in quotes.
+    # If we only had one name, and it had spaces,
+    # we need to enclose it in quotes.
     # Otherwise, it's interpreted as two tags.
     if len(names) == 1 and use_commas:
         result = '"' + result + '"'


### PR DESCRIPTION
I found that `parse_tag_input()` fails when given a single tag that has space. E.g., if you give it a single tag with the name `spa ces`, it returns the string `spa ces`. But that gets interpreted on input as two tags, `spa` and `ces`.  So it needs to be output as `"spa ces"`.

I also added a test for that case.

Thanks for maintaining this package!