### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Django Tagging
 
 This is a generic tagging application for Django projects
 
-http://django-tagging.readthedocs.org/
+https://django-tagging.readthedocs.io/
 
 Note that this application requires Python 2.7 or later, and Django
 1.8 or later. You can obtain Python from http://www.python.org/ and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    'django': ('http://readthedocs.org/docs/django/en/latest/', None),
+    'django': ('https://django.readthedocs.io/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.