### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 python:
     - 3.7
     - 3.8
+    
+arch:
+    - amd64
+    - ppc64le
+    
 services:
     - postgresql
     - mysql


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 